### PR TITLE
Avoid "dismiss all" notification when only one notification is created

### DIFF
--- a/modules/notifications.js
+++ b/modules/notifications.js
@@ -240,7 +240,7 @@ define([
                     growl(text, _.extend({
                         header: cultureService.localize('w20.core.notifications.severity.notification'),
                         life: 3000
-                    }, _config.options && _config.options.notify || {}, options), 'icon-info-sign', 'jGrowl-notification', system);
+                    }, _config.options && _config.options.notify || {}, options), 'icon-info-sign', 'jGrowl-info', system);
 
                     if (persistent) {
                         notificationHistoryService.addNotification('info', text);


### PR DESCRIPTION
I think, there is a bug when a notification is added. A closer message is added and header is not shown.
jGrowl is confused about 'jGrowl-notification' class.